### PR TITLE
chore: magic link arg classes now properly take all required params

### DIFF
--- a/custom/lib/MagicLinkArgsBase.php
+++ b/custom/lib/MagicLinkArgsBase.php
@@ -2,12 +2,10 @@
 
 namespace Passage\Client;
 
-use OpenAPI\Client\Model\MagicLinkType;
-
 readonly class MagicLinkArgsBase
 {
     public function __construct(
-        public readonly MagicLinkType $type,
+        public readonly string $type,
         public readonly bool $send,
     ) {
     }

--- a/custom/lib/MagicLinkWithEmailArgs.php
+++ b/custom/lib/MagicLinkWithEmailArgs.php
@@ -4,8 +4,17 @@ namespace Passage\Client;
 
 final readonly class MagicLinkWithEmailArgs extends MagicLinkArgsBase
 {
+    /**
+     * @param string $email The email to send the magic link to
+     * @param string $type The type of magic link to send, should be OpenAPI\Client\Model\MagicLinkType
+     * @param bool $send Whether to send the magic link
+     * @see OpenAPI\Client\Model\MagicLinkType
+     */
     public function __construct(
         public readonly string $email,
+        string $type,
+        bool $send,
     ) {
+        parent::__construct($type, $send);
     }
 }

--- a/custom/lib/MagicLinkWithPhoneArgs.php
+++ b/custom/lib/MagicLinkWithPhoneArgs.php
@@ -4,8 +4,17 @@ namespace Passage\Client;
 
 final readonly class MagicLinkWithPhoneArgs extends MagicLinkArgsBase
 {
+    /**
+     * @param string $phone The phone number to send the magic link to
+     * @param string $type The type of magic link to send, should be OpenAPI\Client\Model\MagicLinkType
+     * @param bool $send Whether to send the magic link
+     * @see OpenAPI\Client\Model\MagicLinkType
+     */
     public function __construct(
         public readonly string $phone,
+        string $type,
+        bool $send,
     ) {
+        parent::__construct($type, $send);
     }
 }

--- a/custom/lib/MagicLinkWithUserArgs.php
+++ b/custom/lib/MagicLinkWithUserArgs.php
@@ -2,13 +2,22 @@
 
 namespace Passage\Client;
 
-use OpenAPI\Client\Model\MagicLinkChannel;
-
 final readonly class MagicLinkWithUserArgs extends MagicLinkArgsBase
 {
+    /**
+     * @param string $userId The Passage user ID
+     * @param string $channel The channel to send the magic link to, should be OpenAPI\Client\Model\MagicLinkChannel
+     * @param string $type The type of magic link to send, should be OpenAPI\Client\Model\MagicLinkType
+     * @param bool $send Whether to send the magic link
+     * @see OpenAPI\Client\Model\MagicLinkChannel
+     * @see OpenAPI\Client\Model\MagicLinkType
+     */
     public function __construct(
         public readonly string $userId,
-        public readonly MagicLinkChannel $channel,
+        public readonly string $channel,
+        string $type,
+        bool $send,
     ) {
+        parent::__construct($type, $send);
     }
 }

--- a/custom/test/AuthTest.php
+++ b/custom/test/AuthTest.php
@@ -3,6 +3,10 @@
 namespace Passage\Test;
 
 use Dotenv\Dotenv;
+use OpenAPI\Client\Model\MagicLinkType;
+use Passage\Client\MagicLinkWithEmailArgs;
+use Passage\Client\MagicLinkWithPhoneArgs;
+use Passage\Client\MagicLinkWithUserArgs;
 use UnexpectedValueException;
 use PHPUnit\Framework\TestCase;
 use Passage\Client\Passage;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- fixes issue where the three magic link args were not able to take in the required `send` or `type` params from their base class
- fixes issue where the magic link options were not optional in the `createMagicLink` signature

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
